### PR TITLE
Example install files for Elasticsearch and Python 3.

### DIFF
--- a/INSTALL-Elasticsearch.md
+++ b/INSTALL-Elasticsearch.md
@@ -1,0 +1,96 @@
+
+# Elasticsearch v7.x
+
+You can go to Elasticsearch's website and download the appropriate
+elastic search.
+
+    https://www.elastic.co/start
+
+Elasticsearch needs to be running locally to use Observatory. Observatory
+expects to connect to Elasticsearch on port 9200 of localhost.
+
+## Example Debian style system setup
+
+Managing and installing Elasticsearch on a Debian style Linux or
+on macOS varies slightly. These instructions describe installing
+Elasticsearch community edition on a Debian/Ubuntu based Linux.
+
+### Installing Elasticsearch v7.5
+
++ Elasticsearch
+    + https://www.elastic.co/guide/en/elasticsearch/reference/7.5/deb.html
+
+Steps I took to install Elasticsearch v7.5 under Ubuntu 18.04 LTS
+
+```shell
+    sudo apt install apt-transport-https # Already had the newest 
+    sudo apt install openjdk-11-jdk
+    # Import Elastic Search GPG Key
+    wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch |\
+        sudo apt-key add -
+    echo "deb https://artifacts.elastic.co/packages/oss-7.x/apt stable main" |\
+        sudo tee -a /etc/apt/sources.list.d/elastic-7.x.list
+    sudo apt update
+    sudo apt install elasticsearch-oss
+```
+
+Setup up for systemd for auto start on boot. NOTE: If you want manual
+restart just do daemon-reload, then use the usual systemd start
+and stop verbs with elasticsearch.service.
+
+```shell
+    sudo systemctl daemon-reload
+    sudo systemctl enable elasticsearch.service
+```
+
+Checking to see if Elasticsearch is running.
+
+```shell
+    sudo systemctl status elasticsearch.service
+```
+
+Starting Elasticsearch
+
+```shell
+    sudo systemctl start elasticsearch.service
+```
+
+Stopping Elasticsearch
+
+```shell
+    sudo systemctl stop elasticsearch.service
+```
+
+To remove elasticsearch from auto start use the usually systemd
+disable.
+
+```shell
+    sudo systemctl disable elasticsearch.service
+```
+
+
+### Installing Elasticsearch, macOS using ports
+
+Homebrew is the documented way on the Elasticsearch website for
+installing on macOS. You can also install via MacPorts. 
+My quick notes for [install elasticsearch using MacPorts](macOS-elasticsearch.html). 
+
+If you are using MacPorts you can start elasticsearch
+with
+
+```
+    sudo port load elasticsearch
+```
+
+and stop it with
+
+```
+    sudo port unload elasticsearch
+```
+
+or if you want to restart Elasticsearch
+
+```
+    sudo port reload elasticsearch
+```
+

--- a/INSTALL-Elasticsearch.md
+++ b/INSTALL-Elasticsearch.md
@@ -13,3 +13,76 @@ Specific instructions for your operating system
     + `sudo port install elasticsearch`
 
 Elasticsearch can be run locally. By default it runs port 9200 of localhost (e.g. http://localhost:9200/).
+
+
+### Managing Elasticsearch on Debian/Ubuntu
+
+Elasticsearch is setup up for `systemd`. Beloew are common
+`systemctl` commands for working with the elasticsearch service.
+
+If you want manual restart just do `daemon-reload`, then use the 
+usual `systemctl` start and stop verbs with elasticsearch.service.
+
+```shell
+    sudo systemctl daemon-reload
+    sudo systemctl enable elasticsearch.service
+```
+
+Checking to see if Elasticsearch is running.
+
+```shell
+    sudo systemctl status elasticsearch.service
+```
+
+Starting Elasticsearch
+
+```shell
+    sudo systemctl start elasticsearch.service
+```
+
+Stopping Elasticsearch
+
+```shell
+    sudo systemctl stop elasticsearch.service
+```
+
+To remove elasticsearch from auto start use the usually systemd
+disable.
+
+```shell
+    sudo systemctl disable elasticsearch.service
+```
+
+
+### Manage Elasticsearch on macOS with MacPorts
+
+MacPorts includes a version of Elasticsearch that will
+work with Observatory.
+
+Installing Elasticsearch server and client. 
+
+```shell
+    sudo port install elasticsearch
+```
+
+You can manage your Elasticsearch service with the ports command.
+
+If you are using MacPorts you can start elasticsearch
+with
+
+```
+    sudo port load elasticsearch
+```
+
+and stop it with
+
+```
+    sudo port unload elasticsearch
+```
+
+If you need to restart Elasticsearch you can use the reload option.
+
+```
+    sudo port reload elasticsearch
+```
+

--- a/INSTALL-Elasticsearch.md
+++ b/INSTALL-Elasticsearch.md
@@ -12,4 +12,4 @@ Specific instructions for your operating system
 + Installing Elasticsearch on macOS with [MacPorts](https://www.macports.org/)
     + `sudo port install elasticsearch`
 
-Elasticsearch can be run locally. By default it runs port 9200 of localhost (e.g. http://localhost:9200/_status).
+Elasticsearch can be run locally. By default it runs port 9200 of localhost (e.g. http://localhost:9200/).

--- a/INSTALL-Elasticsearch.md
+++ b/INSTALL-Elasticsearch.md
@@ -12,4 +12,4 @@ Specific instructions for your operating system
 + Installing Elasticsearch on macOS with [MacPorts](https://www.macports.org/)
     + `sudo port install elasticsearch`
 
-Elasticsearch can be run locally. By default it runs port 9200 of localhost (e.g. https://localhost:9200/_status).
+Elasticsearch can be run locally. By default it runs port 9200 of localhost (e.g. http://localhost:9200/_status).

--- a/INSTALL-Elasticsearch.md
+++ b/INSTALL-Elasticsearch.md
@@ -1,96 +1,15 @@
-
-# Elasticsearch v7.x
+## Elasticsearch v7.x
 
 You can go to Elasticsearch's website and download the appropriate
 elastic search.
 
     https://www.elastic.co/start
 
-Elasticsearch needs to be running locally to use Observatory. Observatory
-expects to connect to Elasticsearch on port 9200 of localhost.
+Specific instructions for your operating system
 
-## Example Debian style system setup
++ [Install Elasticsearch on Linux with Debian Package](https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html)
++ [Installing Elasticsearch on Windows with `.zip`](https://www.elastic.co/guide/en/elasticsearch/reference/current/zip-windows.html)
++ Installing Elasticsearch on macOS with [MacPorts](https://www.macports.org/)
+    + `sudo port install elasticsearch`
 
-Managing and installing Elasticsearch on a Debian style Linux or
-on macOS varies slightly. These instructions describe installing
-Elasticsearch community edition on a Debian/Ubuntu based Linux.
-
-### Installing Elasticsearch v7.5
-
-+ Elasticsearch
-    + https://www.elastic.co/guide/en/elasticsearch/reference/7.5/deb.html
-
-Steps I took to install Elasticsearch v7.5 under Ubuntu 18.04 LTS
-
-```shell
-    sudo apt install apt-transport-https # Already had the newest 
-    sudo apt install openjdk-11-jdk
-    # Import Elastic Search GPG Key
-    wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch |\
-        sudo apt-key add -
-    echo "deb https://artifacts.elastic.co/packages/oss-7.x/apt stable main" |\
-        sudo tee -a /etc/apt/sources.list.d/elastic-7.x.list
-    sudo apt update
-    sudo apt install elasticsearch-oss
-```
-
-Setup up for systemd for auto start on boot. NOTE: If you want manual
-restart just do daemon-reload, then use the usual systemd start
-and stop verbs with elasticsearch.service.
-
-```shell
-    sudo systemctl daemon-reload
-    sudo systemctl enable elasticsearch.service
-```
-
-Checking to see if Elasticsearch is running.
-
-```shell
-    sudo systemctl status elasticsearch.service
-```
-
-Starting Elasticsearch
-
-```shell
-    sudo systemctl start elasticsearch.service
-```
-
-Stopping Elasticsearch
-
-```shell
-    sudo systemctl stop elasticsearch.service
-```
-
-To remove elasticsearch from auto start use the usually systemd
-disable.
-
-```shell
-    sudo systemctl disable elasticsearch.service
-```
-
-
-### Installing Elasticsearch, macOS using ports
-
-Homebrew is the documented way on the Elasticsearch website for
-installing on macOS. You can also install via MacPorts. 
-My quick notes for [install elasticsearch using MacPorts](macOS-elasticsearch.html). 
-
-If you are using MacPorts you can start elasticsearch
-with
-
-```
-    sudo port load elasticsearch
-```
-
-and stop it with
-
-```
-    sudo port unload elasticsearch
-```
-
-or if you want to restart Elasticsearch
-
-```
-    sudo port reload elasticsearch
-```
-
+Elasticsearch can be run locally. By default it runs port 9200 of localhost (e.g. https://localhost:9200/_status).

--- a/INSTALL-Python3.md
+++ b/INSTALL-Python3.md
@@ -1,0 +1,53 @@
+
+# Install Python 3.x
+
+Getting your Python setup right on your system is important.
+Otherwise you find yourself in the realm of confusing error messages.
+This documents focuses on getting Python 3 up and running on
+Debian/Ubuntu Linux based systems as well as on macOS via MacPorts.
+Your milleage may very.
+
+## Python versions issues
+
+It is possible to use your default OS provided python if it is version
+>= 3.6. Many distributions still ship with version 2.7 out of the box
+and pipy's pip corresponding to version 2.7. Observatory REQUIRES 
+a modern Python and pip.  On some systems, a version of 3.6 (or
+better) is available using the commands `python3` and `pip3`. Others
+let you install Python 3 via their package manager and use the verison
+three use those commands. This is true on Debian/Ubuntu based systems as
+well as macOS's MacPorts.
+
+
+## Getting the right Python and Pip
+
+### Debian/Ubuntu
+
+Debian based systems still ship with older versions of Python by
+default. We want to use a modern Python 3.x. Make sure it is 
+installed and available along with the related version of pip.
+
+```
+    sudo apt install python3 python3-pip
+```
+
+### macOS with MacPorts
+
+If you are using macOS and MacPorts you can take a similar
+approach (presumably Homebrew for macOS uses the Debian
+style commands)
+
+```
+    sudo port install python38
+    sudo port install py38-pip
+```
+
+At this point you should be able to envoke the Python interpreter
+using the `python3` command. You should see the version
+of python and pip with these commands.
+
+```
+    python3 --version
+    python3 -m pip --version
+```
+

--- a/INSTALL-Python3.md
+++ b/INSTALL-Python3.md
@@ -7,15 +7,19 @@ This documents focuses on getting Python 3 up and running on
 Debian/Ubuntu Linux based systems as well as on macOS via MacPorts.
 Your milleage may very.
 
+> If you are running on an Intel style processor (e.g. most Macs and Windows
+> machines) you can use a Python distribution called [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
+> This is often the easiest approach to getting a modern Python on your machine. Otherwise continue
+> on reading.
+
 ## Python versions issues
 
 It is possible to use your default OS provided python if it is version
->= 3.6. Many distributions still ship with version 2.7 out of the box
-and pipy's pip corresponding to version 2.7. Observatory REQUIRES 
-a modern Python and pip.  On some systems, a version of 3.6 (or
-better) is available using the commands `python3` and `pip3`. Others
-let you install Python 3 via their package manager and use the verison
-three use those commands. This is true on Debian/Ubuntu based systems as
+greater than 3.x. Many distributions still ship with version 2.7 out of the box
+and pipy's pip corresponding to version 2.7. On some systems, a version of 3.x
+is available using the commands `python3` and `pip3`. Others let you install 
+Python 3 and its pip via their package manager and use the package manager
+select default versions and/or names. This is true on Debian/Ubuntu based systems as
 well as macOS's MacPorts.
 
 
@@ -49,5 +53,18 @@ of python and pip with these commands.
 ```
     python3 --version
     python3 -m pip --version
+```
+
+### Install Python modules using the right pip
+
+Often you'll need some additional modules with your
+Python development environment. To make sure we're using the right
+Python and pip you can use the `-m` interpreter option to 
+install the desired module.  Example of installing `py_dataset`
+and Elasticsearch python modules.
+
+```shell
+    python3 -m pip install py_dataset
+    python3 -m pip install elasticsearch
 ```
 


### PR DESCRIPTION
Anticipating that many of our projects may take advantage of modern Python or Elasticsearch I've included two example installation instructions. If those tools were requirements then they could be linked into README.md or INSTALL.md or if not needed removed.